### PR TITLE
Better transition period handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uuidable (1.0.2)
+    uuidable (1.0.3)
       activerecord (>= 4.2, < 7.2)
       mysql-binuuid-rails (>= 1.3, < 2)
       uuidtools (>= 2.1, < 3)

--- a/lib/uuidable.rb
+++ b/lib/uuidable.rb
@@ -17,4 +17,5 @@ end
 
 require 'uuidable/migration'
 require 'uuidable/v1_migration_helpers'
+require 'uuidable/v1_model_migration'
 require 'uuidable/active_record'

--- a/lib/uuidable/v1_model_migration.rb
+++ b/lib/uuidable/v1_model_migration.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Uuidable
+  # Temporary helpers for transition period when migrating to v1
+  module V1ModelMigration
+    extend ActiveSupport::Concern
+
+    included do
+      before_validation do
+        attributes.each_key do |attr_name|
+          next unless attr_name.include?(V1MigrationHelpers::OLD_POSTFIX)
+
+          new_attr_name = attr_name.gsub(V1MigrationHelpers::OLD_POSTFIX, '')
+          public_send("#{attr_name}=", attributes[new_attr_name].to_s)
+        end
+      end
+    end
+  end
+end

--- a/lib/uuidable/version.rb
+++ b/lib/uuidable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Uuidable
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end


### PR DESCRIPTION
Not all `__old` columns were handled correctly. Now they are filled from the actual ones in before_validation hooks until all `__old` columns removed.

\+ handled situation with models which have some `_uuid` columns, but don't have general `uuid`.